### PR TITLE
Change redirectURI to https

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ metadata:
   name: launcher
 secret: my-secret-password
 redirectURIs:
-  - "http://$(oc get route launcher --template={{.spec.host}})"
+  - "https://$(oc get route launcher --template={{.spec.host}})"
 grantMethod: prompt
 EOF
 ```


### PR DESCRIPTION
Since #24 has been fixed, secured route is created. This means that OAuthClient callback URI should use "https" protocol.

ping @gastaldi this is follow up for our route fix from last Friday.