### PR TITLE
Add keycloakClientId into oauth spec and config map

### DIFF
--- a/example/launcher_cr.yaml
+++ b/example/launcher_cr.yaml
@@ -13,6 +13,7 @@ spec:
     enabled: true
     keycloakUrl: http://keycloakUrl
     keycloakRealm: launcher
+    keycloakClientId: launcher
 
   git:
     providers:

--- a/pkg/apis/launcher/v1alpha2/launcher_types.go
+++ b/pkg/apis/launcher/v1alpha2/launcher_types.go
@@ -20,9 +20,10 @@ type LauncherSpec struct {
 
 // OAuthConfig defines the OAuth configuration
 type OAuthConfig struct {
-	Enabled       bool   `json:"enabled"`
-	KeycloakURL   string `json:"keycloakUrl,omitempty"`
-	KeycloakRealm string `json:"keycloakRealm,omitempty"`
+	Enabled          bool   `json:"enabled"`
+	KeycloakURL      string `json:"keycloakUrl,omitempty"`
+	KeycloakRealm    string `json:"keycloakRealm,omitempty"`
+	KeycloakClientID string `json:"keycloakClientId,omitempty"`
 }
 
 // OpenShiftConfig defines the OpenShift configuration

--- a/pkg/controller/launcher/launcher_controller.go
+++ b/pkg/controller/launcher/launcher_controller.go
@@ -172,12 +172,12 @@ func (r *ReconcileLauncher) Reconcile(request reconcile.Request) (reconcile.Resu
 		}
 
 		for _, gitConfig := range instance.Spec.Git.GitProviders {
-		index := findByID(gitProviders, gitConfig.ID)
+			index := findByID(gitProviders, gitConfig.ID)
 			if index == -1 {
 				return reconcile.Result{}, fmt.Errorf("could not find git provider config with ID: '%s'", gitConfig.ID)
 			}
-		gitProviders[index].ClientProperties.ClientID = gitConfig.ClientID
-		gitProviders[index].ServerProperties.ClientSecret = gitConfig.ClientSecret
+			gitProviders[index].ClientProperties.ClientID = gitConfig.ClientID
+			gitProviders[index].ServerProperties.ClientSecret = gitConfig.ClientSecret
 			gitProviders[index].ServerProperties.OauthURL = gitConfig.OauthURL
 		}
 		d, err := yaml.Marshal(&gitProviders)
@@ -187,6 +187,7 @@ func (r *ReconcileLauncher) Reconcile(request reconcile.Request) (reconcile.Resu
 		if instance.Spec.OAuth.KeycloakURL != "" {
 			data["launcher.keycloak.url"] = instance.Spec.OAuth.KeycloakURL
 			data["launcher.keycloak.realm"] = instance.Spec.OAuth.KeycloakRealm
+			data["launcher.keycloak.client.id"] = instance.Spec.OAuth.KeycloakClientID
 		} else {
 			data["launcher.oauth.openshift.url"] = instance.Spec.OpenShift.ConsoleURL + "/oauth/authorize"
 		}


### PR DESCRIPTION
Follow up on #32 and #34 - adding a field for KeyCloak client ID.

@edewit @ia3andy would you mind reviewing and publishing new version, please?